### PR TITLE
feat: GitHub OAuth login + API key manager

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -108,6 +108,10 @@ services:
       - REPLAY_RCON_BASE_PORT=28000
       - VTUBER_STREAM_CLIENT_IMAGE=claudetorio-vtuber-stream-client
       - VTUBER_STREAM_BASE_PORT=5002
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - GITHUB_CALLBACK_URL=${GITHUB_CALLBACK_URL:-http://localhost:3000/auth/callback}
+      - JWT_SECRET=${JWT_SECRET:-dev-jwt-secret-change-me}
     depends_on:
       postgres:
         condition: service_healthy

--- a/machines/game-server/docker-compose.yml
+++ b/machines/game-server/docker-compose.yml
@@ -101,6 +101,10 @@ services:
       - TWITCH_CHANNEL=${TWITCH_CHANNEL:-}
       - VTUBER_STREAM_CLIENT_IMAGE=claudetorio-vtuber-stream-client
       - VTUBER_STREAM_BASE_PORT=5002
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - GITHUB_CALLBACK_URL=${GITHUB_CALLBACK_URL:-https://app.claudetorio.ai/auth/callback}
+      - JWT_SECRET=${JWT_SECRET:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/broker/app/config.py
+++ b/packages/broker/app/config.py
@@ -71,6 +71,11 @@ class Config:
     TWITCH_CLIENT_ID: str = os.getenv("TWITCH_CLIENT_ID", "")
     TWITCH_CLIENT_SECRET: str = os.getenv("TWITCH_CLIENT_SECRET", "")
     TWITCH_CHANNEL: str = os.getenv("TWITCH_CHANNEL", "")
+    # GitHub OAuth
+    GITHUB_CLIENT_ID: str = os.getenv("GITHUB_CLIENT_ID", "")
+    GITHUB_CLIENT_SECRET: str = os.getenv("GITHUB_CLIENT_SECRET", "")
+    GITHUB_CALLBACK_URL: str = os.getenv("GITHUB_CALLBACK_URL", "http://localhost:3000/auth/callback")
+    JWT_SECRET: str = os.getenv("JWT_SECRET", "dev-jwt-secret-change-me")
 
     @classmethod
     def get_udp_port(cls, slot: int) -> int:

--- a/packages/broker/app/dependencies.py
+++ b/packages/broker/app/dependencies.py
@@ -1,5 +1,6 @@
 from typing import AsyncGenerator, Optional
 
+import jwt
 from fastapi import Header, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,3 +28,29 @@ async def require_worker_key(authorization: Optional[str] = Header(None)):
     if config.RUN_WORKER_API_KEY:
         if not authorization or authorization != f"Bearer {config.RUN_WORKER_API_KEY}":
             raise HTTPException(401, "Invalid worker key")
+
+
+def _decode_jwt(token: str) -> dict:
+    try:
+        return jwt.decode(token, config.JWT_SECRET, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(401, "Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(401, "Invalid token")
+
+
+async def get_current_user_optional(authorization: Optional[str] = Header(None)) -> Optional[dict]:
+    """Decode JWT from Authorization header, or return None if absent."""
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    try:
+        return _decode_jwt(authorization[7:])
+    except HTTPException:
+        return None
+
+
+async def get_current_user(authorization: Optional[str] = Header(None)) -> dict:
+    """Decode JWT from Authorization header, or raise 401."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(401, "Missing authorization header")
+    return _decode_jwt(authorization[7:])

--- a/packages/broker/app/models.py
+++ b/packages/broker/app/models.py
@@ -163,6 +163,19 @@ class RunStep(Base):
     )
 
 
+class GitHubUser(Base):
+    __tablename__ = "github_users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    github_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
+    github_username: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    avatar_url: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    github_token: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(server_default=text("NOW()"))
+    updated_at: Mapped[Optional[datetime]] = mapped_column(server_default=text("NOW()"), onupdate=datetime.now)
+
+
 class ChatMessage(Base):
     __tablename__ = "chat_messages"
 

--- a/packages/broker/app/routes/__init__.py
+++ b/packages/broker/app/routes/__init__.py
@@ -5,6 +5,7 @@ from .system import router as system_router
 from .runs import router as runs_router
 from .internal import router as internal_router
 from .chat import router as chat_router
+from .auth import router as auth_router
 
 all_routers = [
     sessions_router,
@@ -14,4 +15,5 @@ all_routers = [
     runs_router,
     internal_router,
     chat_router,
+    auth_router,
 ]

--- a/packages/broker/app/routes/auth.py
+++ b/packages/broker/app/routes/auth.py
@@ -1,0 +1,147 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import config
+from ..dependencies import get_db, get_current_user
+from ..models import GitHubUser
+from ..schemas import (
+    GitHubAuthUrlResponse,
+    GitHubCallbackRequest,
+    AuthTokenResponse,
+    AuthUser,
+    AuthMeResponse,
+)
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL = "https://api.github.com/user"
+GITHUB_USER_EMAILS_URL = "https://api.github.com/user/emails"
+
+
+@router.get("/github", response_model=GitHubAuthUrlResponse)
+async def github_auth_url():
+    if not config.GITHUB_CLIENT_ID:
+        raise HTTPException(500, "GitHub OAuth not configured")
+    params = {
+        "client_id": config.GITHUB_CLIENT_ID,
+        "redirect_uri": config.GITHUB_CALLBACK_URL,
+        "scope": "user:email read:user",
+    }
+    return GitHubAuthUrlResponse(url=f"{GITHUB_AUTHORIZE_URL}?{urlencode(params)}")
+
+
+@router.post("/github/callback", response_model=AuthTokenResponse)
+async def github_callback(body: GitHubCallbackRequest, db: AsyncSession = Depends(get_db)):
+    if not config.GITHUB_CLIENT_ID or not config.GITHUB_CLIENT_SECRET:
+        raise HTTPException(500, "GitHub OAuth not configured")
+
+    # Exchange code for access token
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(
+            GITHUB_TOKEN_URL,
+            json={
+                "client_id": config.GITHUB_CLIENT_ID,
+                "client_secret": config.GITHUB_CLIENT_SECRET,
+                "code": body.code,
+                "redirect_uri": config.GITHUB_CALLBACK_URL,
+            },
+            headers={"Accept": "application/json"},
+        )
+        if token_resp.status_code != 200:
+            raise HTTPException(400, "Failed to exchange code with GitHub")
+        token_data = token_resp.json()
+        access_token = token_data.get("access_token")
+        if not access_token:
+            error = token_data.get("error_description", "Unknown error")
+            raise HTTPException(400, f"GitHub OAuth error: {error}")
+
+        # Fetch user info
+        gh_headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+        user_resp = await client.get(GITHUB_USER_URL, headers=gh_headers)
+        if user_resp.status_code != 200:
+            raise HTTPException(400, "Failed to fetch GitHub user info")
+        user_data = user_resp.json()
+
+        # Fetch primary email if not public
+        email = user_data.get("email")
+        if not email:
+            emails_resp = await client.get(GITHUB_USER_EMAILS_URL, headers=gh_headers)
+            if emails_resp.status_code == 200:
+                for e in emails_resp.json():
+                    if e.get("primary"):
+                        email = e.get("email")
+                        break
+
+    github_id = user_data["id"]
+    github_username = user_data.get("login", "")
+    avatar_url = user_data.get("avatar_url", "")
+
+    # Upsert GitHubUser
+    result = await db.execute(select(GitHubUser).where(GitHubUser.github_id == github_id))
+    gh_user = result.scalar_one_or_none()
+    if gh_user:
+        gh_user.github_username = github_username
+        gh_user.email = email
+        gh_user.avatar_url = avatar_url
+        gh_user.github_token = access_token
+        gh_user.updated_at = datetime.now(timezone.utc)
+    else:
+        gh_user = GitHubUser(
+            github_id=github_id,
+            github_username=github_username,
+            email=email,
+            avatar_url=avatar_url,
+            github_token=access_token,
+        )
+        db.add(gh_user)
+
+    await db.commit()
+    await db.refresh(gh_user)
+
+    # Create JWT
+    payload = {
+        "sub": str(gh_user.id),
+        "github_id": gh_user.github_id,
+        "github_username": gh_user.github_username,
+        "exp": datetime.now(timezone.utc) + timedelta(days=7),
+    }
+    token = jwt.encode(payload, config.JWT_SECRET, algorithm="HS256")
+
+    auth_user = AuthUser(
+        id=gh_user.id,
+        github_id=gh_user.github_id,
+        github_username=gh_user.github_username,
+        email=gh_user.email,
+        avatar_url=gh_user.avatar_url,
+    )
+    return AuthTokenResponse(token=token, user=auth_user)
+
+
+@router.get("/me", response_model=AuthMeResponse)
+async def auth_me(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(GitHubUser).where(GitHubUser.id == int(current_user["sub"]))
+    )
+    gh_user = result.scalar_one_or_none()
+    if not gh_user:
+        raise HTTPException(404, "User not found")
+    return AuthMeResponse(
+        user=AuthUser(
+            id=gh_user.id,
+            github_id=gh_user.github_id,
+            github_username=gh_user.github_username,
+            email=gh_user.email,
+            avatar_url=gh_user.avatar_url,
+        )
+    )

--- a/packages/broker/app/schemas.py
+++ b/packages/broker/app/schemas.py
@@ -132,6 +132,29 @@ class CompleteRunRequest(BaseModel):
 
 # --- Chat schemas ---
 
+# --- Auth schemas ---
+
+class GitHubAuthUrlResponse(BaseModel):
+    url: str
+
+class GitHubCallbackRequest(BaseModel):
+    code: str
+
+class AuthTokenResponse(BaseModel):
+    token: str
+    user: "AuthUser"
+
+class AuthUser(BaseModel):
+    id: int
+    github_id: int
+    github_username: str
+    email: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+class AuthMeResponse(BaseModel):
+    user: AuthUser
+
+
 class ChatMessageCreate(BaseModel):
     content: str = Field(..., min_length=1, max_length=500)
     username: str = Field(..., min_length=1, max_length=30)

--- a/packages/broker/pyproject.toml
+++ b/packages/broker/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "websockets>=12.0",
     "httpx>=0.27.0",
     "anthropic>=0.40.0",
+    "PyJWT>=2.8.0",
 ]

--- a/packages/broker/uv.lock
+++ b/packages/broker/uv.lock
@@ -129,6 +129,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcrcon" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -144,6 +145,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcrcon", specifier = ">=0.7.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.25" },
@@ -541,6 +543,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
 ]
 
 [[package]]

--- a/packages/frontend/app/auth/callback/page.tsx
+++ b/packages/frontend/app/auth/callback/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { API_BASE } from '@/constants';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function AuthCallbackPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { handleCallback } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code) {
+      setError('No authorization code received');
+      return;
+    }
+
+    let cancelled = false;
+
+    async function exchange() {
+      try {
+        const res = await fetch(`${API_BASE}/api/auth/github/callback`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.detail || `HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        await handleCallback(data.token);
+        router.push('/');
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Authentication failed');
+      }
+    }
+
+    exchange();
+    return () => { cancelled = true; };
+  }, [searchParams, handleCallback, router]);
+
+  if (error) {
+    return (
+      <main className="min-h-screen bg-surface-0 text-white font-[family-name:var(--font-body)] flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <p className="text-red-400">Authentication failed: {error}</p>
+          <Link href="/" className="text-accent-green hover:opacity-80 transition-opacity">
+            Back to home
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-surface-0 text-white font-[family-name:var(--font-body)] flex items-center justify-center">
+      <p className="text-white/60">Authenticating...</p>
+    </main>
+  );
+}

--- a/packages/frontend/components/Auth/ApiKeyManager.tsx
+++ b/packages/frontend/components/Auth/ApiKeyManager.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getApiKeys, saveApiKeys, clearApiKeys, type StoredApiKeys } from '@/utils/api-keys';
+
+export default function ApiKeyManager() {
+  const [keys, setKeys] = useState<StoredApiKeys>({ anthropic: '', openai: '', custom: { url: '', key: '' } });
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setKeys(getApiKeys());
+  }, []);
+
+  function handleSave() {
+    saveApiKeys(keys);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  function handleClear() {
+    clearApiKeys();
+    setKeys({ anthropic: '', openai: '', custom: { url: '', key: '' } });
+  }
+
+  const inputClass =
+    'w-full bg-surface-0 border border-surface-3 px-2 py-1 text-xs text-white/80 focus:outline-none focus:border-accent-green';
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <label className="block text-xs text-white/40 mb-0.5">Anthropic Key</label>
+        <input
+          type="password"
+          value={keys.anthropic}
+          onChange={(e) => setKeys({ ...keys, anthropic: e.target.value })}
+          placeholder="sk-ant-..."
+          className={inputClass}
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-white/40 mb-0.5">OpenAI Key</label>
+        <input
+          type="password"
+          value={keys.openai}
+          onChange={(e) => setKeys({ ...keys, openai: e.target.value })}
+          placeholder="sk-..."
+          className={inputClass}
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-white/40 mb-0.5">Custom API URL</label>
+        <input
+          type="text"
+          value={keys.custom.url}
+          onChange={(e) => setKeys({ ...keys, custom: { ...keys.custom, url: e.target.value } })}
+          placeholder="https://..."
+          className={inputClass}
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-white/40 mb-0.5">Custom API Key</label>
+        <input
+          type="password"
+          value={keys.custom.key}
+          onChange={(e) => setKeys({ ...keys, custom: { ...keys.custom, key: e.target.value } })}
+          placeholder="Optional"
+          className={inputClass}
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={handleSave}
+          className="flex-1 px-2 py-1 bg-accent-green text-black text-xs font-medium transition-colors hover:opacity-80"
+        >
+          {saved ? 'Saved!' : 'Save Keys'}
+        </button>
+        <button
+          onClick={handleClear}
+          className="px-2 py-1 bg-surface-3 text-white/60 text-xs transition-colors hover:text-white/80"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/components/Auth/LoginWidget.tsx
+++ b/packages/frontend/components/Auth/LoginWidget.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import ApiKeyManager from './ApiKeyManager';
+
+export default function LoginWidget() {
+  const { user, loading, isAuthenticated, loginWithGitHub, logout } = useAuth();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [showApiKeys, setShowApiKeys] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+        setShowApiKeys(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  if (loading) return null;
+
+  if (isAuthenticated && user) {
+    return (
+      <div className="relative" ref={ref}>
+        <button
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+          className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+        >
+          {user.avatar_url && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={user.avatar_url}
+              alt=""
+              className="w-6 h-6 rounded-full"
+            />
+          )}
+          <span className="text-white/80 text-sm">{user.github_username}</span>
+        </button>
+
+        {dropdownOpen && (
+          <div className="absolute right-0 top-8 w-72 bg-surface-1 border border-surface-3 shadow-xl z-50">
+            {/* User info */}
+            <div className="p-3 border-b border-surface-3">
+              <div className="text-sm text-white font-medium">{user.github_username}</div>
+              {user.email && (
+                <div className="text-xs text-white/40 truncate">{user.email}</div>
+              )}
+            </div>
+
+            {/* Menu */}
+            <div className="py-1">
+              <button
+                onClick={() => setShowApiKeys(!showApiKeys)}
+                className="w-full text-left px-3 py-2 text-sm text-white/60 hover:bg-surface-2 hover:text-white transition-colors"
+              >
+                {showApiKeys ? 'Hide' : 'Manage'} API Keys
+              </button>
+
+              {showApiKeys && (
+                <div className="px-3 py-2 border-t border-surface-3">
+                  <ApiKeyManager />
+                </div>
+              )}
+
+              <button
+                onClick={() => {
+                  logout();
+                  setDropdownOpen(false);
+                }}
+                className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-surface-2 hover:text-red-300 transition-colors"
+              >
+                Logout
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={loginWithGitHub}
+      className="text-accent-green font-semibold text-sm hover:opacity-80 transition-opacity"
+    >
+      Login
+    </button>
+  );
+}

--- a/packages/frontend/components/Home/HomePage.tsx
+++ b/packages/frontend/components/Home/HomePage.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import BenchmarksList from './BenchmarksList';
 import TournamentCountdown from './TournamentCountdown';
+import LoginWidget from '@/components/Auth/LoginWidget';
 import type { TwitchStream, TwitchVideo } from '@/lib/twitch';
 import type { RunInfo } from '@/interfaces';
 
@@ -40,9 +41,7 @@ export default function HomePage({
         <span className="font-[family-name:var(--font-heading)] font-bold text-lg tracking-wide text-white">
           CLAUDETORIO
         </span>
-        <button className="text-accent-green font-semibold text-sm hover:opacity-80 transition-opacity">
-          Login
-        </button>
+        <LoginWidget />
       </header>
 
       <div className="px-10 py-8 space-y-12">

--- a/packages/frontend/components/StartRunForm.tsx
+++ b/packages/frontend/components/StartRunForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useEscapeKey } from '@/hooks/use-escape-key';
 import { createRun } from '@/services/api';
+import { getApiKeys } from '@/utils/api-keys';
 
 type Provider = 'anthropic' | 'openai' | 'custom';
 type StoredFormData = Partial<{
@@ -78,6 +79,16 @@ export default function StartRunForm({ onClose }: { onClose: () => void }) {
 
   useEscapeKey(onClose);
 
+  // Auto-fill from saved API keys (api-keys manager) if form fields are empty
+  useEffect(() => {
+    const saved = getApiKeys();
+    if (!apiKey && saved.anthropic && provider === 'anthropic') setApiKey(saved.anthropic);
+    if (!apiKey && saved.openai && provider === 'openai') setApiKey(saved.openai);
+    if (!customApiUrl && saved.custom.url) setCustomApiUrl(saved.custom.url);
+    if (!customApiKey && saved.custom.key) setCustomApiKey(saved.custom.key);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     localStorage.setItem(
       FORM_STORAGE_KEY,
@@ -96,6 +107,10 @@ export default function StartRunForm({ onClose }: { onClose: () => void }) {
   function handleProviderChange(p: Provider) {
     setProvider(p);
     setModel(PROVIDER_DEFAULTS[p] || model);
+    // Load the matching saved key for the selected provider
+    const saved = getApiKeys();
+    if (p === 'anthropic') setApiKey(saved.anthropic);
+    else if (p === 'openai') setApiKey(saved.openai);
   }
 
   async function handleSubmit(e: React.FormEvent) {

--- a/packages/frontend/components/Stream/LiveStreamPage.tsx
+++ b/packages/frontend/components/Stream/LiveStreamPage.tsx
@@ -7,6 +7,7 @@ import { fetchLiveRun } from '@/services/api';
 import StreamPlayer from './StreamPlayer';
 import StreamInfoBar from './StreamInfoBar';
 import ChatPanel from '@/components/Chat/ChatPanel';
+import LoginWidget from '@/components/Auth/LoginWidget';
 
 export default function LiveStreamPage({
   initialStream,
@@ -54,9 +55,7 @@ export default function LiveStreamPage({
         <a href="/" className="font-[family-name:var(--font-heading)] font-bold text-lg tracking-wide text-white hover:opacity-80 transition-opacity">
           CLAUDETORIO
         </a>
-        <button className="text-accent-green font-semibold text-sm hover:opacity-80 transition-opacity">
-          Login
-        </button>
+        <LoginWidget />
       </header>
 
       <div className="mx-auto max-w-[1400px] px-6 py-6">

--- a/packages/frontend/components/Stream/StreamPage.tsx
+++ b/packages/frontend/components/Stream/StreamPage.tsx
@@ -2,6 +2,7 @@ import type { StreamDefinition } from '@/lib/streams';
 import StreamPlayer from './StreamPlayer';
 import StreamInfoBar from './StreamInfoBar';
 import ChatPanel from '@/components/Chat/ChatPanel';
+import LoginWidget from '@/components/Auth/LoginWidget';
 
 export default function StreamPage({ stream }: { stream: StreamDefinition }) {
   return (
@@ -11,9 +12,7 @@ export default function StreamPage({ stream }: { stream: StreamDefinition }) {
         <a href="/" className="font-[family-name:var(--font-heading)] font-bold text-lg tracking-wide text-white hover:opacity-80 transition-opacity">
           CLAUDETORIO
         </a>
-        <button className="text-accent-green font-semibold text-sm hover:opacity-80 transition-opacity">
-          Login
-        </button>
+        <LoginWidget />
       </header>
 
       <div className="mx-auto max-w-[1400px] px-6 py-6">

--- a/packages/frontend/contexts/AuthContext.tsx
+++ b/packages/frontend/contexts/AuthContext.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import { API_BASE } from '@/constants';
+import type { AuthUser } from '@/interfaces';
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  loading: boolean;
+  isAuthenticated: boolean;
+  loginWithGitHub: () => Promise<void>;
+  handleCallback: (token: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const TOKEN_KEY = 'claudetorio_jwt';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchMe = useCallback(async (token: string): Promise<AuthUser | null> => {
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data.user;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // On mount, check for existing token
+  useEffect(() => {
+    let cancelled = false;
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    fetchMe(token).then((u) => {
+      if (cancelled) return;
+      setUser(u);
+      if (!u) localStorage.removeItem(TOKEN_KEY);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [fetchMe]);
+
+  const loginWithGitHub = useCallback(async () => {
+    const res = await fetch(`${API_BASE}/api/auth/github`);
+    if (!res.ok) return;
+    const data = await res.json();
+    window.location.href = data.url;
+  }, []);
+
+  const handleCallback = useCallback(async (token: string) => {
+    localStorage.setItem(TOKEN_KEY, token);
+    const u = await fetchMe(token);
+    setUser(u);
+  }, [fetchMe]);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY);
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        loading,
+        isAuthenticated: !!user,
+        loginWithGitHub,
+        handleCallback,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/packages/frontend/interfaces/auth.ts
+++ b/packages/frontend/interfaces/auth.ts
@@ -1,0 +1,7 @@
+export interface AuthUser {
+  id: number;
+  github_id: number;
+  github_username: string;
+  email: string | null;
+  avatar_url: string | null;
+}

--- a/packages/frontend/interfaces/index.ts
+++ b/packages/frontend/interfaces/index.ts
@@ -25,3 +25,5 @@ export type {
 export type { RunInfo, RunStepInfo, TokenUsage } from './run';
 
 export type { ChatMessage } from './chat';
+
+export type { AuthUser } from './auth';

--- a/packages/frontend/utils/api-keys.ts
+++ b/packages/frontend/utils/api-keys.ts
@@ -1,0 +1,45 @@
+const STORAGE_KEY = 'claudetorio_api_keys';
+
+export interface StoredApiKeys {
+  anthropic: string;
+  openai: string;
+  custom: {
+    url: string;
+    key: string;
+  };
+}
+
+const DEFAULT_KEYS: StoredApiKeys = {
+  anthropic: '',
+  openai: '',
+  custom: { url: '', key: '' },
+};
+
+export function getApiKeys(): StoredApiKeys {
+  if (typeof window === 'undefined') return DEFAULT_KEYS;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_KEYS;
+    const parsed = JSON.parse(raw);
+    return {
+      anthropic: parsed.anthropic || '',
+      openai: parsed.openai || '',
+      custom: {
+        url: parsed.custom?.url || '',
+        key: parsed.custom?.key || '',
+      },
+    };
+  } catch {
+    return DEFAULT_KEYS;
+  }
+}
+
+export function saveApiKeys(keys: StoredApiKeys): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(keys));
+}
+
+export function clearApiKeys(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- Add GitHub OAuth sign-in flow (broker handles token exchange + JWT, no NextAuth dependency)
- `LoginWidget` replaces placeholder Login buttons in all 3 headers (home, stream, live)
- Logged-in users see avatar + username dropdown with API key manager and logout
- API key manager saves LLM provider keys to localStorage, auto-fills StartRunForm
- `GitHubUser` model (separate from legacy `User`) with upsert on login
- Production env vars already added to game-server `.env`

## Test plan
- [ ] Click Login → redirects to GitHub OAuth
- [ ] After authorization → redirected back, avatar + username shown in header
- [ ] Refresh → still logged in (JWT in localStorage)
- [ ] Click username → dropdown with API key manager + logout
- [ ] Save API keys → auto-fill in StartRunForm
- [ ] Click Logout → back to Login button
- [ ] Verify on all 3 pages: home, /stream/*, /live

Supersedes #26 (cherry-picked API key manager, replaced NextAuth with custom OAuth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)