### PR TITLE
feat: UI polish — header/footer sizing, fixed footer, dashboard route

### DIFF
--- a/packages/frontend/app/dashboard/page.tsx
+++ b/packages/frontend/app/dashboard/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next';
 import Dashboard from '@/components/Dashboard';
 
 export const metadata: Metadata = {
-  title: { absolute: 'Claudetorio - APP' },
+  title: { absolute: 'Claudetorio - Dashboard' },
 };
 
-export default function ArenaPage() {
+export default function DashboardPage() {
   return <Dashboard />;
 }

--- a/packages/frontend/components/Auth/LoginWidget.tsx
+++ b/packages/frontend/components/Auth/LoginWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import ApiKeyManager from './ApiKeyManager';
 
@@ -54,6 +55,13 @@ export default function LoginWidget() {
 
             {/* Menu */}
             <div className="py-1">
+              <Link
+                href="/dashboard"
+                onClick={() => setDropdownOpen(false)}
+                className="block w-full text-left px-3 py-2 text-sm text-white/60 hover:bg-surface-2 hover:text-white transition-colors"
+              >
+                Dashboard
+              </Link>
               <button
                 onClick={() => setShowApiKeys(!showApiKeys)}
                 className="w-full text-left px-3 py-2 text-sm text-white/60 hover:bg-surface-2 hover:text-white transition-colors"

--- a/packages/frontend/components/Home/BenchmarksList.tsx
+++ b/packages/frontend/components/Home/BenchmarksList.tsx
@@ -31,7 +31,7 @@ export default function BenchmarksList() {
   if (!runs.length) {
     return (
       <div className="text-white/50 font-[family-name:var(--font-body)] text-sm">
-        No benchmarks found. (Start one from <Link className="text-accent-green underline" href="/arena">/arena</Link>)
+        No benchmarks found. (Start one from <Link className="text-accent-green underline" href="/dashboard">/dashboard</Link>)
       </div>
     );
   }

--- a/packages/frontend/components/Home/HomePage.tsx
+++ b/packages/frontend/components/Home/HomePage.tsx
@@ -37,14 +37,14 @@ export default function HomePage({
   return (
     <main className="min-h-screen bg-surface-0 text-white font-[family-name:var(--font-body)]">
       {/* Top bar */}
-      <header className="h-12 bg-surface-1 border-b border-surface-3 flex items-center justify-between px-8">
+      <header className="h-14 bg-surface-1 border-b border-surface-3 flex items-center justify-between px-8">
         <span className="font-[family-name:var(--font-heading)] font-bold text-lg tracking-wide text-white">
           CLAUDETORIO
         </span>
         <LoginWidget />
       </header>
 
-      <div className="px-10 py-8 space-y-12">
+      <div className="px-10 py-8 pb-20 space-y-12">
         {/* STREAMS */}
         <section>
           <h2 className="font-[family-name:var(--font-heading)] text-2xl font-bold mb-6 tracking-wide">
@@ -174,7 +174,7 @@ export default function HomePage({
       </div>
 
       {/* Footer */}
-      <footer className="h-14 bg-surface-1 border-t border-surface-3 flex items-center justify-center gap-14 px-8">
+      <footer className="fixed bottom-0 left-0 right-0 h-12 bg-surface-1 border-t border-surface-3 flex items-center justify-center gap-14 px-8 z-50">
         <a href="https://www.twitch.tv/claudetorio" target="_blank" rel="noopener noreferrer" className="text-[#9146FF] hover:opacity-70 transition-opacity" aria-label="Twitch">
           <svg height="22" viewBox="20 10 1100 270" fill="currentColor"><path d="M170 170h-70v20h70v80H60l-40-40V20h80v70h70zM470 270H230l-40-40V90h80v100h20V90h80v100h20V90h80zM490 90h80v180h-80zM490 20h80v50h-80zM740 170h-70v20h70v80H630l-40-40V20h80v70h70zM920 170h-80v20h80v80H800l-40-40V130l40-40h120zM1120 270h-80V170h-20v100h-80V20h80v70h60l40 40z"/></svg>
         </a>


### PR DESCRIPTION
## Summary
- Adjust header/footer sizing: header slightly larger (`h-14`), footer slightly smaller (`h-12`)
- Fix footer to bottom of viewport with proper content padding
- Add "Dashboard" link to user dropdown menu
- Rename `/arena` route to `/dashboard` and update all references

## Test plan
- [ ] Verify header and footer render at correct sizes
- [ ] Verify footer stays fixed at bottom of viewport
- [ ] Verify Dashboard link appears in user dropdown when logged in
- [ ] Verify `/dashboard` route loads correctly
- [ ] Verify `/arena` references are all updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)